### PR TITLE
hotfix - use default entity name field

### DIFF
--- a/src/main/java/com/example/projectlxp/model/course/Course.java
+++ b/src/main/java/com/example/projectlxp/model/course/Course.java
@@ -10,20 +10,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "courses")
 public class Course {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "instructor_id", nullable = false)
+    @Column(nullable = false)
     private Long instructorId;
 
-    @Column(name = "category_id", nullable = false)
+    @Column(nullable = false)
     private Long categoryId;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false)
     private String title;
 
     @Lob
@@ -37,13 +36,13 @@ public class Course {
     @Column(nullable = false)
     private CourseStatus status = CourseStatus.DRAFT;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @Column(name = "deleted_at")
+    @Column
     private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -103,6 +102,7 @@ public class Course {
     /**
      * Performs a soft delete on this course and cascades the deletion to all associated sections and lectures.
      * <p>
+     * 선요약: {@code @Transactional} 내에서만 호출하세요 안그럼 터짐
      * This method sets the {@code deletedAt} timestamp for the course, all its sections, and all lectures
      * within those sections. The course status is transitioned to {@code DELETED}.
      * <p>

--- a/src/main/java/com/example/projectlxp/model/lecture/Lecture.java
+++ b/src/main/java/com/example/projectlxp/model/lecture/Lecture.java
@@ -1,9 +1,10 @@
 package com.example.projectlxp.model.lecture;
 
-import com.example.projectlxp.exception.BusinessException;
 import com.example.projectlxp.controller.lecture.request.LectureUpdateRequest;
+import com.example.projectlxp.exception.BusinessException;
 import com.example.projectlxp.model.section.Section;
 import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 
 import static com.example.projectlxp.model.lecture.exception.LectureExceptionCode.LECTURE_ALREADY_DELETED;
@@ -11,7 +12,6 @@ import static com.example.projectlxp.model.lecture.exception.LectureExceptionCod
 
 
 @Entity
-@Table(name = "lectures")
 public class Lecture {
 
     @Id
@@ -22,38 +22,38 @@ public class Lecture {
     @JoinColumn(name = "section_id", nullable = false)
     private Section section;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false)
     private String title;
 
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "sort_order", nullable = false)
+    @Column(nullable = false)
     private Integer sortOrder;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private LectureType type;
 
-    @Column(name = "resource_path", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String resourcePath;
 
     @Column
     private Integer duration;
 
-    @Column(name = "previewable", nullable = false)
-    private Boolean previewable = false;
+    @Column(nullable = false)
+    private boolean previewable = false;
 
     @Column(nullable = false)
     private boolean status = false;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @Column(name = "deleted_at")
+    @Column
     private LocalDateTime deletedAt;
 
     @PrePersist
@@ -82,7 +82,7 @@ public class Lecture {
         this.previewable = previewable;
     }
 
-    public static Lecture forCreate(Section section, String title, String description, Integer order, LectureType type,String resourcePath, Integer duration, Boolean isPreviewable) {
+    public static Lecture forCreate(Section section, String title, String description, Integer order, LectureType type, String resourcePath, Integer duration, Boolean isPreviewable) {
 
         return new Lecture(section, title, description, order, type, resourcePath, duration, isPreviewable);
     }
@@ -102,7 +102,7 @@ public class Lecture {
         if (requestDTO.getDescription() != null) {
             this.description = requestDTO.getDescription();
         }
-        if(requestDTO.getOrder() != null) {
+        if (requestDTO.getOrder() != null) {
             updateOrder(requestDTO.getOrder());
         }
         if (requestDTO.getType() != null) {

--- a/src/main/java/com/example/projectlxp/model/section/Section.java
+++ b/src/main/java/com/example/projectlxp/model/section/Section.java
@@ -29,13 +29,13 @@ public class Section {
     @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Lecture> lectures = new ArrayList<>();
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @Column(name = "deleted_at")
+    @Column
     private LocalDateTime deletedAt;
 
     @PrePersist

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:


### PR DESCRIPTION
## 개요
* 현재 `Table` / `Column`의 명칭을 어노테이션 `name` 필드를 활용하여 별도로 부여하고 있음
  * 별도로 부여한 네임과 변수명 매칭이 제대로 관리되지 않으니 차라리 엔티티 내부의 개별 name field 삭제 및 자동으로 명칭 지정되게 변경
* `application.yml`의 `ddl-auto` 값이 여전히 `update`로 되어있음
  * `validate`으로 원복

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다. (컴파일 가능 및 실행 가능 확인)
